### PR TITLE
Fix wrong repository name in the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/almost/react-native-sqlite3.git"
+    "url": "https://github.com/almost/react-native-sqlite.git"
   },
   "keywords": [
     "react-component",
@@ -21,9 +21,9 @@
   "author": "Thomas Parslow",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/almost/react-native-sqlite3/issues"
+    "url": "https://github.com/almost/react-native-sqlite/issues"
   },
-  "homepage": "https://github.com/almost/react-native-sqlite3",
+  "homepage": "https://github.com/almost/react-native-sqlite",
   "dependencies": {
     "react-native": "^0.3.4"
   }


### PR DESCRIPTION
This prevents broken links in the npm website.
