### PR TITLE
Fix for 'RCTDeviceEventEmitter not found' error

### DIFF
--- a/sqlite3.ios.js
+++ b/sqlite3.ios.js
@@ -1,6 +1,6 @@
 // @flow
 var NativeModules = require('react-native').NativeModules;
-var RCTDeviceEventEmitter = require('react-native/Libraries/Device/RCTDeviceEventEmitter');
+var { DeviceEventEmitter } = require('react-native');
 
 var nextId = 0;
 


### PR DESCRIPTION
Fixed according to the RN docs here: https://facebook.github.io/react-native/docs/native-modules-android.html#content
`var { DeviceEventEmitter } = require('react-native')` seems to be the correct solution.
