### PR TITLE
Remove unused DeviceEventEmitter require

### DIFF
--- a/sqlite3.ios.js
+++ b/sqlite3.ios.js
@@ -1,6 +1,5 @@
 // @flow
 var NativeModules = require('react-native').NativeModules;
-var { DeviceEventEmitter } = require('react-native');
 
 var nextId = 0;
 


### PR DESCRIPTION
Hey @almost ! Kinda simple PR here. This just removes the DeviceEventEmitter that is unused. It throws a resolution error anyways:

```
Unable to resolve module RCTDeviceEventEmitter from /Users/pcottle/Dropbox (Personal)/wip/SQLSandbox/node_modules/react-native-sqlite/sqlite3.ios.js
```

I think there are still a few more updates to get this to work with React Native 0.15 but ill try to attack those another day

(Updated version of #36)
