### PR TITLE
Add Database.getName()

### DIFF
--- a/sqlite3.ios.js
+++ b/sqlite3.ios.js
@@ -11,6 +11,7 @@ SQLite3Error.prototype = new Error();
 
 function Database(databaseName, openCallback) {
   this._databaseId = null;
+  this._databaseName = databaseName;
   // List of actions pending database connection
   this._pendingActions = [];
 
@@ -27,6 +28,11 @@ function Database(databaseName, openCallback) {
 }
 
 Database.prototype = {
+
+  getName(): string {
+    return this._databaseName;
+  },
+
   executeSQL (
     sql: string,
     params: Array<?(number|string)>,

--- a/sqlite3.ios.js
+++ b/sqlite3.ios.js
@@ -1,6 +1,5 @@
 // @flow
 var NativeModules = require('react-native').NativeModules;
-var { DeviceEventEmitter } = require('react-native');
 
 var nextId = 0;
 


### PR DESCRIPTION
I feel like the `Database` object should be the canonical instance passed around for all DB-related info. Only issue is that you can't get the DB name once you have the object!

So I added this simple getter so you can pass just the object rather than the DB name alongside it.

Example usage:
https://gist.github.com/pcottle/0435146cc7299b1d4165

note: This is based on a branch with #37 included, so ignore that missing line. I don't think you can open a PR based on another pending PR
