### PR TITLE
[RFC|NeedsWork] Add validate statement bridge method

### DIFF
--- a/AIBSQLite.h
+++ b/AIBSQLite.h
@@ -6,7 +6,7 @@
 //
 
 
-#import <RCTBridgeModule.h>
+#import "./node_modules/react-native/React/Base/RCTBridgeModule.h"
 
 @interface AIBSQLite : NSObject <RCTBridgeModule>
 

--- a/sqlite3.ios.js
+++ b/sqlite3.ios.js
@@ -33,6 +33,22 @@ Database.prototype = {
     return this._databaseName;
   },
 
+  validateSQL (
+    sql: string,
+    params: Array<?(number|string)>,
+    completeCallback: ((error: ?SQLite3Error) => void)
+  ): void {
+     this._addAction(completeCallback, (callback) => {
+      NativeModules.AIBSQLite.validateStatement(this._databaseId, sql, params, (error) => {
+        if (error) {
+          completeCallback(new SQLite3Error(error));
+          return;
+        }
+        completeCallback(null);
+      });
+    });
+  },
+
   executeSQL (
     sql: string,
     params: Array<?(number|string)>,


### PR DESCRIPTION
Alright @almost this diff is super rough since I'm an Objective-C newb, but hoping to get some feedback and improve on it.

In my app that teaches people SQL, I'd like to be able to verify the query they have partially composed before going and executing the whole thing. The verification doesnt need to be 100%, just a best effort (obviously things might arise during actual execution).

So for this diff I added a `validateStatement` method that takes in a SQL statement + params, does the same verification we do in execute, steps it once, and returns if there is any error. Otherwise it closes out the statement and returns null.

Problems so far:
- How should I consolidate the templating / validation logic between `validateStatement` and `prepareStatement`? I tried to do it with a private method body (called synchronously) but since I need to return a `sqlite3_stmt`, I couldn't quite figure out how to throw / catch errors and gave up.
- For some reason I couldn't get Xcode 7.2 to "see" the react header files so I had to make them relative imports :(
- What is the pending action stuff on the JS side? Can you actually queue up statements to a DB before its finished opening? If so thats cool :) I guess I wondered why `getDatabase` was sync...
